### PR TITLE
Improve frame merging resilience and interpolation handling

### DIFF
--- a/bundle_adjustment/visualization/merge.py
+++ b/bundle_adjustment/visualization/merge.py
@@ -34,11 +34,16 @@ def merge_frame_to_video(save_path: Path, flag: str) -> None:
     _out_path = save_path / "video"
 
     frames = sorted(list(_save_path.iterdir()), key=lambda x: int(x.stem.split("_")[0]))
+    if not frames:
+        raise FileNotFoundError(f"No frames found in {_save_path}")
 
     if not _out_path.exists():
         _out_path.mkdir(parents=True, exist_ok=True)
 
     first_frame = cv2.imread(str(frames[0]))
+    if first_frame is None:
+        raise ValueError(f"Failed to read first frame: {frames[0]}")
+
     height, width, _ = first_frame.shape
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
@@ -46,10 +51,15 @@ def merge_frame_to_video(save_path: Path, flag: str) -> None:
         str(_out_path / (flag + ".mp4")), fourcc, 30.0, (width, height)
     )
 
-    for f in tqdm(frames, desc=f"Save {flag}", total=len(frames)):
-        img = cv2.imread(str(f))
-        out.write(img)
-
-    out.release()
+    try:
+        out.write(first_frame)
+        for f in tqdm(frames[1:], desc=f"Save {flag}", total=len(frames)):
+            img = cv2.imread(str(f))
+            if img is None:
+                logger.warning("Skipping unreadable frame: %s", f)
+                continue
+            out.write(img)
+    finally:
+        out.release()
 
     logger.info(f"Video saved to {_out_path / (flag + '.mp4')}")

--- a/prepare_dataset/utils.py
+++ b/prepare_dataset/utils.py
@@ -17,16 +17,24 @@ Date 	By 	Comments
 
 """
 
+import logging
+from pathlib import Path
+from typing import List
+
 import cv2
+import torch
 from tqdm import tqdm
 
-from pathlib import Path
-
-import torch
-
-import logging
-
 logger = logging.getLogger(__name__)
+
+
+def _sorted_frame_paths(frame_dir: Path) -> List[Path]:
+    """Return frame paths sorted by the numeric prefix before the first underscore."""
+
+    return sorted(
+        [p for p in frame_dir.iterdir() if p.is_file()],
+        key=lambda path: int(path.stem.split("_")[0]),
+    )
 
 
 def merge_frame_to_video(
@@ -40,12 +48,17 @@ def merge_frame_to_video(
         _save_path = save_path / "vis" / "img" / flag / person / video_name
         _out_path = save_path / "vis" / "video" / flag / person
 
-    frames = sorted(list(_save_path.iterdir()), key=lambda x: int(x.stem.split("_")[0]))
+    frames = _sorted_frame_paths(_save_path)
+    if not frames:
+        raise FileNotFoundError(f"No frames found in {_save_path}")
 
     if not _out_path.exists():
         _out_path.mkdir(parents=True, exist_ok=True)
 
     first_frame = cv2.imread(str(frames[0]))
+    if first_frame is None:
+        raise ValueError(f"Failed to read first frame: {frames[0]}")
+
     height, width, _ = first_frame.shape
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
@@ -53,39 +66,61 @@ def merge_frame_to_video(
         str(_out_path / video_name) + ".mp4", fourcc, 30.0, (width, height)
     )
 
-    for f in tqdm(frames, desc=f"Save {flag}-{video_name}", total=len(frames)):
-        img = cv2.imread(str(f))
-        out.write(img)
-
-    out.release()
+    try:
+        out.write(first_frame)
+        for f in tqdm(frames[1:], desc=f"Save {flag}-{video_name}", total=len(frames)):
+            img = cv2.imread(str(f))
+            if img is None:
+                logger.warning("Skipping unreadable frame: %s", f)
+                continue
+            out.write(img)
+    finally:
+        out.release()
 
     logger.info(f"Video saved to {_out_path / video_name}.mp4")
 
 
 def process_none(batch_Dict: dict[torch.Tensor], none_index: list):
     """
-    process_none, where from batch_Dict to instead the None value with next frame tensor (or froward frame tensor).
+    Replace ``None`` entries in ``batch_Dict`` using the nearest valid frame.
 
-    Args:
-        batch_Dict (dict): batch in Dict, where include the None value when yolo dont work.
-        none_index (list): none index list map to batch_Dict, here not use this.
-
-    Returns:
-        list: list include the replace value for None value.
+    The function now prefers the next available frame; if no later frame exists,
+    it falls back to the most recent previous frame. This prevents sequences from
+    remaining ``None`` when consecutive frames are missing, which would
+    otherwise break downstream stacking.
     """
 
-    boundary = len(batch_Dict) - 1
-    filter_batch = batch_Dict.copy()
+    if not none_index:
+        return batch_Dict
 
-    for i in none_index:
+    ordered_indices = sorted(batch_Dict.keys())
+    forward_fill = {}
+    backward_fill = {}
 
-        # * if the index is None, we need to replace it with next frame.
-        if batch_Dict[i] is None:
-            next_idx = i + 1
+    last_valid = None
+    for idx in ordered_indices:
+        value = batch_Dict[idx]
+        if value is not None:
+            last_valid = value
+        forward_fill[idx] = last_valid
 
-            if next_idx < boundary:
-                filter_batch[i] = batch_Dict[next_idx]
-            else:
-                filter_batch[i] = batch_Dict[boundary - 1]
+    next_valid = None
+    for idx in reversed(ordered_indices):
+        value = batch_Dict[idx]
+        if value is not None:
+            next_valid = value
+        backward_fill[idx] = next_valid
 
-    return filter_batch
+    filled_batch = batch_Dict.copy()
+    for idx in none_index:
+        if idx not in batch_Dict:
+            continue
+
+        replacement = backward_fill.get(idx) or forward_fill.get(idx)
+        if replacement is None:
+            logger.warning("All frames are missing; index %s remains None", idx)
+            continue
+
+        filled_batch[idx] = replacement
+
+    return filled_batch


### PR DESCRIPTION
## Summary
- add safer frame collection, validation, and logging when merging frames into videos
- fill missing pose or detection frames using nearest available data to avoid None entries breaking pipelines
- align bundle adjustment video export with the same robustness for unreadable or missing frames

## Testing
- python -m compileall prepare_dataset/utils.py bundle_adjustment/visualization/merge.py

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69377f243d1c832ca6922ac268814ed5)